### PR TITLE
fix: make use of QlikView Sans

### DIFF
--- a/src/paint.js
+++ b/src/paint.js
@@ -111,6 +111,7 @@ const wordcloud = () => ({
           return scaleRotate(Math.round(r.real(0, 1) * (layout.Orientations - 1)));
         })
         .fontSize(function (d) { return scale(+d.value); })
+        .font(["QlikView Sans"])
         .on("end", words =>
           draw(words, layout, element, selectValuesFunc, layout.ScaleColor, self.Id, self.Width, self.Height, resolve))
         .start();

--- a/src/styles.less
+++ b/src/styles.less
@@ -1,5 +1,5 @@
 .wordcloud {
-	font-family: Verdana, Geneva, sans-serif
+	font-family: QlikView Sans
 }
 .selected , .selectable{
   cursor: pointer;


### PR DESCRIPTION
For some reason the styling in sense-client seems to have changed in some regard which made the wordcloud to default to an undesired font. Now setting to QlikView Sans

- [x] Test before merge